### PR TITLE
Fix parseGLB bug and GLText reference to self

### DIFF
--- a/src/commands/GLTFScene.js
+++ b/src/commands/GLTFScene.js
@@ -151,8 +151,8 @@ const drawModel = (regl) => {
           data: bitmap,
           min: glConstantToRegl(sampler.minFilter),
           mag: glConstantToRegl(sampler.magFilter),
-          wrapS: glConstantToRegl(sampler.wrapS),
-          wrapT: glConstantToRegl(sampler.wrapT),
+          wrapS: sampler.wrapS ? glConstantToRegl(sampler.wrapS) : "repeat",
+          wrapT: sampler.wrapT ? glConstantToRegl(sampler.wrapT) : "repeat",
         });
         return texture;
       });

--- a/src/commands/GLText.js
+++ b/src/commands/GLText.js
@@ -13,7 +13,7 @@ import { isColorDark, type TextMarker } from "./Text";
 
 // HACK: TinySDF doesn't agree with workers. Until support is added, hack this to make it work.
 // TODO(steel): Upstream the fix in memoizedCreateCanvas.
-if (!self.document) {
+if (typeof self !== "undefined" && !self.document) {
   // $FlowFixMe: Flow doesn't know about OffscreenCanvas.
   self.document = { createElement: () => new OffscreenCanvas(0, 0) };
 }

--- a/src/utils/parseGLB.js
+++ b/src/utils/parseGLB.js
@@ -133,7 +133,7 @@ export default async function parseGLB(arrayBuffer: ArrayBuffer): Promise<GLBMod
     (await Promise.all(
       json.images.map((imgInfo) => {
         const bufferView = json.bufferViews[imgInfo.bufferView];
-        const data = new DataView(binary.buffer, binary.byteOffset + bufferView.byteOffset, bufferView.byteLength);
+        const data = new DataView(binary.buffer, binary.byteOffset + (bufferView.byteOffset || 0), bufferView.byteLength);
         return self.createImageBitmap(new Blob([data], { type: imgInfo.mimeType }));
       })
     ));

--- a/src/utils/parseGLB.js
+++ b/src/utils/parseGLB.js
@@ -133,7 +133,11 @@ export default async function parseGLB(arrayBuffer: ArrayBuffer): Promise<GLBMod
     (await Promise.all(
       json.images.map((imgInfo) => {
         const bufferView = json.bufferViews[imgInfo.bufferView];
-        const data = new DataView(binary.buffer, binary.byteOffset + (bufferView.byteOffset || 0), bufferView.byteLength);
+        const data = new DataView(
+          binary.buffer,
+          binary.byteOffset + (bufferView.byteOffset || 0),
+          bufferView.byteLength
+        );
         return self.createImageBitmap(new Blob([data], { type: imgInfo.mimeType }));
       })
     ));


### PR DESCRIPTION
Make it possible to import GLText in tests (but not use it) by adding a `typeof self` check before accessing `self`.

Also import a couple of small fixes to parseGLB and GLTFScene from https://github.com/cruise-automation/webviz/pull/625 that were never merged.