### PR TITLE
Apply targetOrientation as a matrix multiplication rather than only the heading

### DIFF
--- a/src/camera/CameraStore.test.js
+++ b/src/camera/CameraStore.test.js
@@ -238,40 +238,7 @@ describe("camera store", () => {
         far: 10000,
       });
       expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view2)).toEqual([-25, 0, -3]);
-      expect(vec3.transformMat4([0, 0, 0], [2, 25, 0], view2)).toEqual([0, nearlyZero, -3]);
-    });
-
-    it("follows target orientation in yaw only", () => {
-      const view1 = selectors.view({
-        thetaOffset: 0,
-        phi: 0,
-        distance: 3,
-        target: [2, 0, 0],
-        targetOffset: [25, 0, 0],
-        targetOrientation: [0, 0, 0, 1],
-        perspective: true,
-        fovy: Math.PI / 2,
-        near: 0.01,
-        far: 10000,
-      });
-
-      expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view1)).toEqual([-25, 0, -3]);
-      expect(vec3.transformMat4([0, 0, 0], [2 + 25, 0, 0], view1)).toEqual([0, 0, -3]);
-
-      const view2 = selectors.view({
-        thetaOffset: 0,
-        phi: 0,
-        distance: 3,
-        target: [2, 0, 0],
-        targetOffset: [25, 0, 0],
-        targetOrientation: quat.rotateX([0, 0, 0, 1], [0, 0, 0, 1], Math.PI / 8),
-        perspective: true,
-        fovy: Math.PI / 2,
-        near: 0.01,
-        far: 10000,
-      });
-      expect(vec3.transformMat4([0, 0, 0], [2, 0, 0], view2)).toEqual([-25, 0, -3]);
-      expect(vec3.transformMat4([0, 0, 0], [2 + 25, 7, 0], view2)).toEqual([0, 7, -3]);
+      expect(vec3.transformMat4([0, 0, 0], [2, 25, 0], view2)).toEqual([-50, nearlyZero, -3]);
     });
   });
 });

--- a/src/camera/cameraStateSelectors.js
+++ b/src/camera/cameraStateSelectors.js
@@ -113,7 +113,6 @@ Step 1: translate target to the origin
  <T---C----
 
 Step 2: rotate around the origin so the target points forward
-(Here we use the target's heading only, ignoring other components of its rotation)
 
   |
   ^
@@ -157,7 +156,7 @@ const viewSelector: (CameraState) => Mat4 = createSelector(
   orientationSelector,
   positionSelector,
   targetHeadingSelector,
-  ({ target, targetOffset, perspective }, orientation, position, targetHeading) => {
+  ({ target, targetOffset, targetOrientation, perspective }, orientation, position, targetHeading) => {
     const m = mat4.identity([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
     // apply the steps described above in reverse because we use right-multiplication
@@ -174,7 +173,7 @@ const viewSelector: (CameraState) => Mat4 = createSelector(
     mat4.translate(m, m, vec3.negate(TEMP_VEC3, targetOffset));
 
     // 2. rotate target to point forward
-    mat4.rotateZ(m, m, targetHeading);
+    mat4.multiply(m, m, mat4.fromQuat(TEMP_MAT, targetOrientation));
 
     // 1. move target to the origin
     vec3.negate(TEMP_VEC3, target);


### PR DESCRIPTION
Previously, regl-worldview assumed a Z-up world and would extract a heading from `targetOrientation` that was applied as a rotation around the Z-axis. This made it impossible to apply arbitrary rotations to the camera. In this change, `targetOrientation` is transformed to a rotation matrix and applied normally. If the previous behavior is desired, calling code should extract a heading and build a new quaternion from the Z axis rotation only.