### PR TITLE
Fix camera position in orthographic mode

### DIFF
--- a/src/camera/cameraStateSelectors.test.js
+++ b/src/camera/cameraStateSelectors.test.js
@@ -1,0 +1,28 @@
+// @flow
+
+//  Copyright (c) 2018-present, GM Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import { vec3, quat } from "gl-matrix";
+
+import selectors from "./cameraStateSelectors";
+import { DEFAULT_CAMERA_STATE } from "./CameraStore";
+
+describe("cameraStateSelectors", () => {
+  it("apply translate for targetOrientation for orthographic mode", () => {
+    const cameraState = {
+      ...DEFAULT_CAMERA_STATE,
+      perspective: false,
+      targetOrientation: quat.fromEuler([0, 0, 0, 0], 90, 0, 0),
+    };
+
+    const matrix = selectors.view(cameraState);
+    const location = [0, 0, 0];
+    vec3.transformMat4(location, location, matrix);
+
+    expect(location).toEqual([0, 0, -2500]);
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,7 @@ module.exports = {
     symlinks: false,
     alias: {
       "~": path.resolve(__dirname),
-      "regl-worldview": path.resolve(__dirname),
+      "@foxglove/regl-worldview": path.resolve(__dirname),
       // The Buffer bundled by webpack copies data when doing Buffer.from(sharedArrayBuffer).
       // Force use of the version in webviz-core/node_modules.
       buffer$: path.resolve(`${__dirname}/packages/webviz-core/node_modules/buffer`),


### PR DESCRIPTION
When in orthographic mode, we apply an extra translation to avoid clipping. This change
ensures this extra translation is aligned with the targetOrientation.