### PR TITLE
Apply `points` translation before applyPose() in fromGeometry vertex shader

### DIFF
--- a/src/utils/fromGeometry.js
+++ b/src/utils/fromGeometry.js
@@ -39,7 +39,7 @@ export default (positions: Vec3[], elements: Vec3[]) => (regl: any): ReglCommand
     #WITH_POSE
 
     void main () {
-      vec3 p = applyPose(scale * point) + offset;
+      vec3 p = applyPose(scale * point + offset);
       vColor = color;
       gl_Position = projection * view * vec4(p, 1);
     }


### PR DESCRIPTION
## Summary

Previously, translation was being applied too late so it happened in the world coordinate frame instead of relative to the pose. This had the effect of ignoring pose orientation for `marker.points` translations.

## Test plan

Tested with storybooks in Foxglove Studio. Cube lists and sphere lists both suffered from this bug, and are fixed after this patch. No other marker types appeared to have regressed.

## Versioning impact

Either patch since this is just a bugfix, or minor since the rendered output will change for any cube lists or sphere lists that had a non-identity pose orientation.