### PR TITLE
Add support for KHR_materials_unlit extension

### DIFF
--- a/common/fixtures/UnlitTest.glb
+++ b/common/fixtures/UnlitTest.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e07b68c6fd9fbf73d372c610a681b89d6b013bdd1a506e46a411df82210a2481
+size 3992

--- a/src/stories/GLTFScene.stories.js
+++ b/src/stories/GLTFScene.stories.js
@@ -101,4 +101,26 @@ storiesOf("Worldview/GLTFScene", module)
         </GLTFScene>
       </Worldview>
     );
+  })
+  .add("UnlitTest", () => {
+    const model = require("~/common/fixtures/UnlitTest.glb");
+    return (
+      <Worldview
+        defaultCameraState={{
+          distance: 25,
+          thetaOffset: (-3 * Math.PI) / 4,
+        }}>
+        <Axes />
+        <Grid />
+        <GLTFScene model={model}>
+          {{
+            pose: {
+              position: { x: 0, y: 0, z: 0 },
+              orientation: { x: 0, y: 0, z: 0, w: 1 },
+            },
+            scale: { x: 1, y: 1, z: 1 },
+          }}
+        </GLTFScene>
+      </Worldview>
+    );
   });

--- a/src/utils/parseGLB.js
+++ b/src/utils/parseGLB.js
@@ -16,7 +16,7 @@ export type GLBModel = {
   images?: ImageBitmap[],
 };
 
-const SUPPORTED_EXTENSIONS = ["KHR_draco_mesh_compression"];
+const SUPPORTED_EXTENSIONS = ["KHR_draco_mesh_compression", "KHR_materials_unlit"];
 
 // Parse a GLB file: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0
 //


### PR DESCRIPTION
Adds support for unlit materials. Normals are ignored for unlit materials (they are allowed to be completely absent, which _normally_ worldview does not handle properly).

https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit

before | after 
-- | --
<img width="179" alt="image" src="https://user-images.githubusercontent.com/14237/151233611-26240c17-03fc-4cf3-b83c-5092f0c9cceb.png"> | <img width="169" alt="image" src="https://user-images.githubusercontent.com/14237/151233674-ebeefad2-bae4-4c28-a729-732bf0b0902d.png">
