### PR TITLE
GLTFScene: ignore primitives with unsupported modes

### DIFF
--- a/src/commands/GLTFScene.js
+++ b/src/commands/GLTFScene.js
@@ -172,6 +172,12 @@ const drawModel = (regl) => {
     // helper to draw the primitives comprising a mesh
     function drawMesh(mesh, nodeMatrix) {
       for (const primitive of mesh.primitives) {
+        if ((primitive.mode ?? 4) !== 4) {
+          console.warn(
+            `GLTFScene: ignoring glTF primitive with mode ${primitive.mode}, only TRIANGLES are currently supported`
+          );
+          continue;
+        }
         const material = model.json.materials[primitive.material];
         const texInfo = material.pbrMetallicRoughness.baseColorTexture;
 


### PR DESCRIPTION
glTF supports rendering primitives other than "triangle list" by setting the `mode` property on a mesh primitive. To avoid rendering errors, GLTFScene should validate that this property is set to 4 (TRIANGLES) because that's the only mode this code actually supports.