### PR TITLE
Apply pose to arrow markers defined by two points

### DIFF
--- a/src/commands/Arrows.js
+++ b/src/commands/Arrows.js
@@ -41,12 +41,16 @@ const generateArrowPrimitives = (markers: Arrow[]) => {
     let dir;
     if (marker.points && marker.points.length === 2) {
       const [start, end] = marker.points;
-      basePosition = [start.x, start.y, start.z];
-      const tipPosition = [end.x, end.y, end.z];
+      const posePosition = pointToVec3(marker.pose.position);
+      const poseOrientation = orientationToVec4(marker.pose.orientation);
+
+      basePosition = vec3.add([0, 0, 0], posePosition, [start.x, start.y, start.z]);
+      const tipPosition = vec3.add([0, 0, 0], posePosition, [end.x, end.y, end.z]);
       const length = vec3.distance(basePosition, tipPosition);
 
       dir = vec3.subtract([0, 0, 0], tipPosition, basePosition);
       vec3.normalize(dir, dir);
+      vec3.transformQuat(dir, dir, poseOrientation);
       orientation = quat.rotationTo([0, 0, 0, 0], UNIT_X_VECTOR, dir);
 
       headWidthX = headWidthY = marker.scale.y;


### PR DESCRIPTION
<!-- Thanks for contributing to Worldview! To help us understand and review your PR, please fill out the following sections: -->

## Summary

Previously, the `pose` field for arrow markers was applied if the `points[]` array length !== 2, but would be ignored for arrow markers defined by two points. This changes the behavior of two-point arrow markers to use the pose.

## Test plan

Foxglove Studio storybook (see screenshot).

<img width="577" alt="Screen Shot 2022-01-27 at 7 45 26 PM" src="https://user-images.githubusercontent.com/195374/151484797-2e1b4a50-432f-41da-b33f-c8abe6f7e836.png">

## Versioning impact

Conservatively, this should be a major version bump since it changes the rendering behavior. But only in the case where you set pose to something other than identity for a two-point arrow marker, and relied on it being ignored. So we could call it a bug fix.
